### PR TITLE
Two word clarification of the environmentBlendMode attrib

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -190,7 +190,7 @@ partial interface XRSession {
 };
 </pre>
 
-The <dfn attribute for="XRSession">environmentBlendMode</dfn> attribute MUST report the {{XREnvironmentBlendMode}} value that matches [=blend technique=] performed by the [=XR Compositor=].
+The <dfn attribute for="XRSession">environmentBlendMode</dfn> attribute MUST report the {{XREnvironmentBlendMode}} value that matches [=blend technique=] currently being performed by the [=XR Compositor=].
 
 - A blend mode of <dfn enum-value for="XREnvironmentBlendMode">opaque</dfn> MUST be reported if the [=XR Compositor=] is using [=opaque environment blending=].
 


### PR DESCRIPTION
Minor clarification that should fix #15. Makes it explicit that the `environmentBlendMode` reflects the blending behavior **currently** being used.