### PR TITLE
Add first person observer view

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -246,11 +246,11 @@ NOTE: Developers may request access to an [=/XR Device=]'s camera, should one be
 First Person Observer Views {#first-person-observer}
 --------------------------------
 
-Many AR devices have a camera, however the camera is typically not aligned with the eyes. When doing video capture of the session for streaming or saving to a file, it is suboptimal to simply composite this camera feed with one of the rendered eye feeds as there will be an internal offset. Devices may use reprojection or other tricks to fix up the stream, but some may expose a third [=view=], the <dfn>first-person observer view</dfn>, which has an [=view/eye=] of {{XREye/"none"}}.
+Many AR devices have a camera, however the camera is typically not aligned with the eyes. When doing video capture of the session for streaming or saving to a file, it is suboptimal to simply composite this camera feed with one of the rendered eye feeds as there will be an internal offset. Devices may use reprojection or other tricks to fix up the stream, but some may expose a [=secondary view=], the <dfn>first-person observer view</dfn>, which has an [=view/eye=] of {{XREye/"none"}}.
 
-Content MUST explicitly opt-in to receiving a [=first-person observer view=] by enabling the "[=additional-views=]" [=feature descriptor=].
+Content MUST explicitly opt-in to receiving a [=first-person observer view=] by enabling the "[=secondary view/secondary-views=]" [=feature descriptor=].
 
-Enabling the "[=additional-views=]" feature for a session that supports  [=first-person observer views=] SHOULD NOT enable the [=first-person observer view=] unconditionally on every frame of the session, rather it will only expose this view in the {{XRViewerPose/views}} array for frames when capture is going on.
+Enabling the "[=secondary view/secondary-views=]" feature for a session that supports  [=first-person observer views=] SHOULD NOT enable the [=first-person observer view=] unconditionally on every frame of the session, rather it will only expose this view in the {{XRViewerPose/views}} array for frames when capture is going on.
 
 While the {{XRSession}} has a [=blend technique=] exposed by the {{XRSession/environmentBlendMode}}, [=first-person observer views=] always use [=alpha-blend environment blending=].
 

--- a/index.bs
+++ b/index.bs
@@ -47,7 +47,8 @@ spec: webxr-1;
     type: dfn; text: feature descriptor
     type: dfn; text: view
     type: dfn; text: eye; for: view
-    type: dfn; text: additional-views
+    type: dfn; text: secondary view
+    type: dfn; text: secondary-views; for:secondary view
 </pre>
 
 <pre class="anchors">

--- a/index.bs
+++ b/index.bs
@@ -44,6 +44,9 @@ spec: webxr-1;
     type: dfn; text: xr compositor
     type: dfn; text: native origin
     type: dfn; text: viewer reference space
+    type: dfn; text: feature descriptor
+    type: dfn; text: view
+    type: dfn; text: eye; for: view
 </pre>
 
 <pre class="anchors">
@@ -238,6 +241,18 @@ NOTE: Future modules may enable automatic or manual pixel occlusion with the [=r
 The [=XR Compositor=] MUST NOT automatically grant the page access to any additional information such as camera intrinsics, media streams, real-world geometry, etc.
 
 NOTE: Developers may request access to an [=/XR Device=]'s camera, should one be exposed through the existing [[mediacapture-streams|Media Capture and Streams]] specification. However, doing so does not provide a mechanism to query the {{XRRigidTransform}} between the camera's location and the [=native origin=] of the [=viewer reference space=]. It also does not provide a guaranteed way to determine the camera intrinsics necessary to match the view of the [=real-world environment=]. As such, performing effective computer vision algorithms wil be significantly hampered. Future modules or specifications may enable such functionality.
+
+First Person Observer Views {#first-person-observer}
+--------------------------------
+
+Many AR devices have a camera, however the camera is typically not aligned with the eyes. When doing video capture of the session for streaming or saving to a file, it is suboptimal to simply composite this camera feed with one of the rendered eye feeds as there will be an internal offset. Devices may use reprojection or other tricks to fix up the stream, but some may expose a third [=view=], the <dfn>first-person observer view</dfn>, which has an [=view/eye=] of {{XREye/"none"}}.
+
+Most content will not expect more than two [=view=]s, and content MUST explicitly opt-in to receiving a [=first-person observer view=] by enabling a "<dfn>first-person-observer</dfn>" [=feature descriptor=].
+
+Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable this feature to ensure maximum compatibility.
+
+Enabling the "[=first-person-observer=]" feature for a session SHOULD NOT enable [=first-person observer view=] unconditionally on every frame of the session, rather it will only expose this view in the {{XRViewerPose/views}} array for frames when capture is going on. If the  [=first-person observer view=] has a lower native frame rate than that of the device, the user-agent MAY choose to surface the [=first-person observer view=] in the {{XRViewerPose/views}} array every other frame, or at whatever rate it wishes. Content that enables "[=first-person-observer=]" is expected to be able to handle changes in the size of {{XRViewerPose/views}} from frame to frame.
+
 
 Privacy & Security Considerations {#privacy-security}
 =================================

--- a/index.bs
+++ b/index.bs
@@ -253,6 +253,18 @@ Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable this
 
 Enabling the "[=first-person-observer=]" feature for a session SHOULD NOT enable [=first-person observer view=] unconditionally on every frame of the session, rather it will only expose this view in the {{XRViewerPose/views}} array for frames when capture is going on. If the  [=first-person observer view=] has a lower native frame rate than that of the device, the user-agent MAY choose to surface the [=first-person observer view=] in the {{XRViewerPose/views}} array every other frame, or at whatever rate it wishes. Content that enables "[=first-person-observer=]" is expected to be able to handle changes in the size of {{XRViewerPose/views}} from frame to frame.
 
+[=First-person observer views=] MAY use a different [=blend technique=] over the primary [=views=]. In such a case, this [=blend technique=] MAY be exposed on the {{XRView}} through {{XRView/overrideBlendMode}}.
+
+The <dfn attribute for=XRView>overrideBlendMode</dfn> attribute is <code>null</code> for all primary [=views=], and is the [=view=]'s [=blend technique=] for [=views=] where the [=blend technique=] differs from the {{XRSession/environmentBlendMode}}.
+
+Note: Content should not use the {{XRView/overrideBlendMode}} to determine whether or not to do things like rendering a background, rather it should use it to tweak how rendering is done to better produce an equivalent-looking rendering.
+
+<pre class="idl">
+partial interface XRView {
+  readonly attribute XREnvironmentBlendMode? overrideBlendMode;
+};
+</pre>
+
 
 Privacy & Security Considerations {#privacy-security}
 =================================

--- a/index.bs
+++ b/index.bs
@@ -47,6 +47,7 @@ spec: webxr-1;
     type: dfn; text: feature descriptor
     type: dfn; text: view
     type: dfn; text: eye; for: view
+    type: dfn; text: additional-views
 </pre>
 
 <pre class="anchors">
@@ -247,21 +248,17 @@ First Person Observer Views {#first-person-observer}
 
 Many AR devices have a camera, however the camera is typically not aligned with the eyes. When doing video capture of the session for streaming or saving to a file, it is suboptimal to simply composite this camera feed with one of the rendered eye feeds as there will be an internal offset. Devices may use reprojection or other tricks to fix up the stream, but some may expose a third [=view=], the <dfn>first-person observer view</dfn>, which has an [=view/eye=] of {{XREye/"none"}}.
 
-Most content will not expect more than two [=view=]s, and content MUST explicitly opt-in to receiving a [=first-person observer view=] by enabling a "<dfn>first-person-observer</dfn>" [=feature descriptor=].
+Content MUST explicitly opt-in to receiving a [=first-person observer view=] by enabling the "[=additional-views=]" [=feature descriptor=].
 
-Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable this feature to ensure maximum compatibility.
+Enabling the "[=additional-views=]" feature for a session that supports  [=first-person observer views=] SHOULD NOT enable the [=first-person observer view=] unconditionally on every frame of the session, rather it will only expose this view in the {{XRViewerPose/views}} array for frames when capture is going on.
 
-Enabling the "[=first-person-observer=]" feature for a session SHOULD NOT enable [=first-person observer view=] unconditionally on every frame of the session, rather it will only expose this view in the {{XRViewerPose/views}} array for frames when capture is going on. If the  [=first-person observer view=] has a lower native frame rate than that of the device, the user-agent MAY choose to surface the [=first-person observer view=] in the {{XRViewerPose/views}} array every other frame, or at whatever rate it wishes. Content that enables "[=first-person-observer=]" is expected to be able to handle changes in the size of {{XRViewerPose/views}} from frame to frame.
+While the {{XRSession}} has a [=blend technique=] exposed by the {{XRSession/environmentBlendMode}}, [=first-person observer views=] always use [=alpha-blend environment blending=].
 
-[=First-person observer views=] MAY use a different [=blend technique=] over the primary [=views=]. In such a case, this [=blend technique=] MAY be exposed on the {{XRView}} through {{XRView/overrideBlendMode}}.
-
-The <dfn attribute for=XRView>overrideBlendMode</dfn> attribute is <code>null</code> for all primary [=views=], and is the [=view=]'s [=blend technique=] for [=views=] where the [=blend technique=] differs from the {{XRSession/environmentBlendMode}}.
-
-Note: Content should not use the {{XRView/overrideBlendMode}} to determine whether or not to do things like rendering a background, rather it should use it to tweak how rendering is done to better produce an equivalent-looking rendering.
+Content may wish to know which view is the [=first-person observer view=] so that it can account for the different [=blend technique=], or choose to render UI elements differently. {{XRView}} objects that correspond to the [=first-person observer view=] have their {{isFirstPersonObserver}} attribute returning <code>true</code>.
 
 <pre class="idl">
 partial interface XRView {
-  readonly attribute XREnvironmentBlendMode? overrideBlendMode;
+  readonly attribute boolean isFirstPersonObserver;
 };
 </pre>
 


### PR DESCRIPTION
This adds a first-person-observer feature flag that can be used to signal support for a first person observer view.


cc @cabanier @thetuvix


Fixes #53