### PR TITLE
[editorial] removed invalid URL as previous link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5,7 +5,6 @@ Group: immersivewebwg
 Status: ED
 TR: https://www.w3.org/TR/webxr-ar-module-1/
 ED: https://immersive-web.github.io/webxr-ar-module/
-Previous Version: https://www.w3.org/TR/2019/WD-webxr-ar-module-1-20210824/
 Repository: immersive-web/webxr-ar-module
 Level: 1
 Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web-wg/


### PR DESCRIPTION
This PR removes previous version link (contains wrong year right after /TR/).
GHAction for streamlined publication seems adding one previous URL (from database) and history link (by spec shortname) before compiling file for /TR/, and having no previous URL could be fine for streamline publication. (so, [2021/Dec/23 version](https://www.w3.org/TR/2021/WD-webxr-ar-module-1-20211223/) has two previous links.)
I could not reproduce to add history link (e.g. using `!History'), so not included in this PR.