### PR TITLE
update GHAction with WD -> CRD

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -23,7 +23,7 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-immersive-web-wg/2021Sep/0004.html
           W3C_BUILD_OVERRIDE: |
-            status: WD
+            status: CRD
 
 # not set 'warning' to BUILD_FAIL_ON (not to cause error by bikeshed warning?)
 

--- a/index.bs
+++ b/index.bs
@@ -9,6 +9,9 @@ Repository: immersive-web/webxr-ar-module
 Level: 1
 Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web-wg/
 
+Implementation Report: https://wpt.fyi/results/webxr/ar-module?label=experimental&label=master&aligned
+WPT Path Prefix: webxr/ar-module
+
 !Participate: <a href="https://github.com/immersive-web/webxr-ar-module/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/webxr-ar-module/issues">open issues</a>)
 !Participate: <a href="https://lists.w3.org/Archives/Public/public-immersive-web-wg/">Mailing list archive</a>
 !Participate: <a href="irc://irc.w3.org:6665/">W3C's #immersive-web IRC</a>


### PR DESCRIPTION
to be merged after publication of CRS, (tentatively) scheduled as 2022-11-01

material used for CRS publication is at (just for a record in this repository): https://github.com/immersive-web/webxr-ar-module/tree/crs-20221101/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/webxr-ar-module/pull/88.html" title="Last updated on Nov 2, 2022, 6:13 AM UTC (3df2901)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-ar-module/88/0afac29...himorin:3df2901.html" title="Last updated on Nov 2, 2022, 6:13 AM UTC (3df2901)">Diff</a>